### PR TITLE
DERIVATIVO-10: use oa:Annotation instead of sc:Annotation

### DIFF
--- a/config/iiif_templates.yml
+++ b/config/iiif_templates.yml
@@ -10,7 +10,7 @@ canvas :
   "@type" : "sc:Canvas"
   images : []
 image :
-  "@type" : "sc:Annotation"
+  "@type" : "oa:Annotation"
   motivation : "sc:Painting"
   resource :
     "@type" : "dctypes:Image"


### PR DESCRIPTION
Please review and, if pertinent and correct, please merge and deploy.

I'd deploy (after pull-request acceptance and merge) but Ubuntu 18.04 and ruby-opencv don't play nice due to mismatched libraries requirements, thus preventing a successful bundle install.

The above also means that I was not able to run specs.

Finally, I'm not familiar with the derivativo codebase, and I may have missed a dependency, etc.

Ticket DERIVATIVO-10 contains additional details.