### PR TITLE
Update derivativo.yml to support ffprobe location override (DERIVATIVO-64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ Note that some features (and the test suite) won't run properly if you don't hav
 
 ```
 ffmpeg_binary_path: '/path/to/ffmpeg'
+ffmpeg_binary_path: '/path/to/ffprobe'
 ghostscript_binary_path: '/path/to/gs'
 ```
+
+Make sure not to set the above overrides if you want to use the binary on your path.
 
 Note that the Tika jar location always needs to be specified in `config/derivativo.yml` because it's not a standalone executable like other binaries and needs to be run with the `java -jar` command:
 
@@ -47,6 +50,7 @@ And depending on how you install LibreOffice, the internal office binary may not
 ```
 soffice_binary_path: '/Applications/LibreOffice.app/Contents/MacOS/soffice'
 ```
+But once again, omit this override if you want to refer to the version on your path.
 
 ## Development Notes
 

--- a/config/initializers/derivativo.rb
+++ b/config/initializers/derivativo.rb
@@ -2,6 +2,9 @@
 
 DERIVATIVO = Rails.application.config_for(:derivativo)
 
+FFMPEG.ffmpeg_binary = DERIVATIVO['ffmpeg_binary_path'] if DERIVATIVO['ffmpeg_binary_path'].present?
+FFMPEG.ffprobe_binary = DERIVATIVO['ffprobe_binary_path'] if DERIVATIVO['ffprobe_binary_path'].present?
+
 # If no working_directory is set, use default tmpdir.
 if DERIVATIVO['working_directory'].blank?
   DERIVATIVO['working_directory'] = Dir.tmpdir

--- a/config/templates/derivativo.template.yml
+++ b/config/templates/derivativo.template.yml
@@ -1,7 +1,8 @@
 default: &default
   remote_request_api_key: 'changethis'
-  ffmpeg_binary_path: 'ffmpeg'
-  soffice_binary_path: 'soffice'
+  #ffmpeg_binary_path: '/usr/local/bin/ffmpeg'
+  #ffprobe_binary_path: '/usr/local/bin/ffprobe'
+  #ghostscript_binary_path: 'gs'
   ghostscript_binary_path: 'gs'
   tika_jar_path: '/path/to/your/tika-app.jar'
 


### PR DESCRIPTION
Also updated README to indicate that binary overrides should not be put into place if you want to use the binary on your path.