### PR TITLE
DERIVATIVO-90: For PDFs, fedora_get_original_image_dimensions now only loads the first PDF page (and this is much faster)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,8 @@ gem 'active_fedora_relsint', :git => 'https://github.com/cul/active_fedora_relsi
 gem 'blacklight', '~> 7.22'
 gem 'view_component', '~> 2.51.0'
 # Use imogen for generating images
-# gem 'imogen', '0.3.2'
-gem 'imogen', git: 'https://github.com/cul/imogen.git', branch: 'iiif_tile_generation_fixes'
+gem 'imogen', '0.4.0'
+#gem 'imogen', git: 'https://github.com/cul/imogen.git', branch: 'iiif_tile_generation_fixes'
 gem 'ruby-vips', '~> 2.0.16'
 #gem 'imogen', :path => '../imogen'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,14 +28,6 @@ GIT
       thread
 
 GIT
-  remote: https://github.com/cul/imogen.git
-  revision: 93fe37dcf7ff7f9f0b2d843bcc71f80a7b1b9d79
-  branch: iiif_tile_generation_fixes
-  specs:
-    imogen (0.4.0.pre.rc.1)
-      ruby-vips
-
-GIT
   remote: https://github.com/samvera-deprecated/jettywrapper.git
   revision: 6b03c21726a83dcecf09d9b20683bfcd63f106d1
   branch: master
@@ -216,6 +208,8 @@ GEM
     httpclient (2.8.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    imogen (0.4.0)
+      ruby-vips
     iso-639 (0.3.5)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -504,7 +498,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.1)
   capistrano-rvm (~> 0.1)
   cul_hydra!
-  imogen!
+  imogen (= 0.4.0)
   jbuilder (~> 2.0)
   jettywrapper (>= 2.0.5)!
   jquery-rails

--- a/app/models/concerns/derivativo/iiif/fedora_property_retrieval.rb
+++ b/app/models/concerns/derivativo/iiif/fedora_property_retrieval.rb
@@ -47,7 +47,12 @@ module Derivativo::Iiif::FedoraPropertyRetrieval
             original_image_width = movie.width
             original_image_height = movie.height
           else
-            Imogen.with_image(image_path) do |img|
+            vips_opts = {}
+            # If the source is a PDF, only load the first page.
+            # Loading all pages can be VERY slow, especially for large PDFs.
+            vips_opts[:page] = 1 if image_path.end_with?('.pdf')
+
+            Imogen.with_image(image_path, vips_opts) do |img|
               original_image_width = img.width
               original_image_height = img.height
             end
@@ -61,6 +66,11 @@ module Derivativo::Iiif::FedoraPropertyRetrieval
             original_image_width = movie.width
             original_image_height = movie.height
           else
+            vips_opts = {}
+            # If the source is a PDF, only load the first page.
+            # Loading all pages can be VERY slow, especially for large PDFs.
+            vips_opts[:page] = 1 if image_path.end_with?('.pdf')
+
             Imogen.with_image(image_path) do |img|
               original_image_width = img.width
               original_image_height = img.height


### PR DESCRIPTION
Also update to imogen v0.4.0